### PR TITLE
fix: Base paths refactor

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,8 +8,8 @@ const baseUrl = getBaseUrl();
 <header>
 	<nav>
 		<div class="site-branding">
-			<img src="https://blog.trustyai.org/trustyai-logo.svg" alt="TrustyAI Logo" class="logo" />
-			<h2><a href="https://blog.trustyai.org/">{SITE_TITLE}</a></h2>
+			<img src={`${import.meta.env.BASE_URL}/trustyai-logo.svg`} alt="TrustyAI Logo" class="logo" />
+			<h2><a href={`${import.meta.env.BASE_URL}`}>{SITE_TITLE}</a></h2>
 		</div>
 		<div class="internal-links">
 			<HeaderLink href={`${baseUrl}/research`}>Research</HeaderLink>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,8 +8,10 @@ const baseUrl = getBaseUrl();
 <header>
 	<nav>
 		<div class="site-branding">
-			<img src={`${import.meta.env.BASE_URL}/trustyai-logo.svg`} alt="TrustyAI Logo" class="logo" />
-			<h2><a href={`${import.meta.env.BASE_URL}`}>{SITE_TITLE}</a></h2>
+			<a href={`${baseUrl}`}>
+				<img src={`${baseUrl}/trustyai-logo.svg`} alt="TrustyAI Logo" class="logo" />
+			</a>
+			<h2><a href={`${baseUrl}`}>{SITE_TITLE}</a></h2>
 		</div>
 		<div class="internal-links">
 			<HeaderLink href={`${baseUrl}/research`}>Research</HeaderLink>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,8 @@
 ---
 import HeaderLink from './HeaderLink.astro';
 import { SITE_TITLE } from '../consts';
+import { getBaseUrl } from '../utils/urls';
+const baseUrl = getBaseUrl();
 ---
 
 <header>
@@ -10,11 +12,11 @@ import { SITE_TITLE } from '../consts';
 			<h2><a href="https://blog.trustyai.org/">{SITE_TITLE}</a></h2>
 		</div>
 		<div class="internal-links">
-			<HeaderLink href="https://blog.trustyai.org/research">Research</HeaderLink>
-			<HeaderLink href="https://blog.trustyai.org/engineering">Engineering</HeaderLink>
-			<HeaderLink href="https://blog.trustyai.org/community">Community</HeaderLink>
-			<HeaderLink href="https://blog.trustyai.org/authors">Authors</HeaderLink>
-			<HeaderLink href="https://trustyai.org/docs/main/main" target="_blank">Documentation</HeaderLink>
+			<HeaderLink href={`${baseUrl}/research`}>Research</HeaderLink>
+			<HeaderLink href={`${baseUrl}/engineering`}>Engineering</HeaderLink>
+			<HeaderLink href={`${baseUrl}/community`}>Community</HeaderLink>
+			<HeaderLink href={`${baseUrl}/authors`}>Authors</HeaderLink>
+			<HeaderLink href="https://trustyai-explainability.github.io/trustyai-site/main/main.html" target="_blank">Documentation</HeaderLink>
 		</div>
 		<div class="social-links">
 			<a href="https://fosstodon.org/@trustyai" target="_blank">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,7 +4,6 @@ import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
-import { getImageUrl } from '../utils/urls';
 
 type Props = CollectionEntry<'blog'>['data'];
 
@@ -60,7 +59,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 		<main>
 			<article>
 				<div class="hero-image">
-					{heroImage && <img width={1020} height={510} src={getImageUrl(heroImage)} alt="" />}
+					{heroImage && <img width={1020} height={510} src={heroImage} alt="" />}
 				</div>
 				<div class="prose">
 					<div class="title">

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -3,9 +3,10 @@ import { getCollection } from 'astro:content';
 import BaseHead from '../../components/BaseHead.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
-import { getAuthorUrl, getAssetUrl } from '../../utils/urls';
+import { getBaseUrl } from '../../utils/urls';
 
 const authors = await getCollection('authors');
+const baseUrl = getBaseUrl();
 ---
 
 <html lang="en">
@@ -22,10 +23,10 @@ const authors = await getCollection('authors');
 					{
 						authors.map((author) => (
 							<li class="author-card">
-								<a href={getAuthorUrl(author.id)}>
+								<a href={`${baseUrl}/authors/${author.id}/`}>
 									{author.data.avatar && (
 										<img
-											src={author.data.avatar.startsWith('/') ? getAssetUrl(author.data.avatar) : author.data.avatar}
+											src={author.data.avatar}
 											alt={author.data.name}
 											class="author-avatar"
 										/>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -12,24 +12,6 @@ const posts = (await getCollection('blog')).sort(
 
 const researchPosts = posts.filter(post => post.data.track === 'research');
 const engineeringPosts = posts.filter(post => post.data.track === 'engineering');
-
-// Helper function to fix hero image URLs
-const getImageUrl = (heroImage) => {
-	if (!heroImage) return '';
-	return heroImage.startsWith('/') ? `https://blog.trustyai.org${heroImage}` : heroImage;
-};
-
-// Helper function to get the correct post URL
-const getPostUrl = (post) => {
-	if (post.data.track === 'research') {
-		return `https://blog.trustyai.org/research/${post.id.replace('research/', '')}`;
-	} else if (post.data.track === 'engineering') {
-		return `https://blog.trustyai.org/engineering/${post.id.replace('engineering/', '')}`;
-	} else {
-		// For posts not in subdirectories
-		return `https://blog.trustyai.org/blog/${post.id}`;
-	}
-};
 ---
 
 <!doctype html>
@@ -125,8 +107,8 @@ const getPostUrl = (post) => {
 					{
 						researchPosts.map((post) => (
 							<li>
-								<a href={getPostUrl(post)}>
-									<img width={720} height={360} src={getImageUrl(post.data.heroImage)} alt="" />
+								<a href={post.id}>
+									<img width={720} height={360} src={post.data.heroImage} alt="" />
 									<h4 class="title">{post.data.title}</h4>
 									<p class="date">
 										<FormattedDate date={post.data.pubDate} />
@@ -144,8 +126,8 @@ const getPostUrl = (post) => {
 					{
 						engineeringPosts.map((post) => (
 							<li>
-								<a href={getPostUrl(post)}>
-									<img width={720} height={360} src={getImageUrl(post.data.heroImage)} alt="" />
+								<a href={post.id}>
+									<img width={720} height={360} src={post.data.heroImage} alt="" />
 									<h4 class="title">{post.data.title}</h4>
 									<p class="date">
 										<FormattedDate date={post.data.pubDate} />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -12,6 +12,7 @@ const posts = (await getCollection('blog')).sort(
 
 const researchPosts = posts.filter(post => post.data.track === 'research');
 const engineeringPosts = posts.filter(post => post.data.track === 'engineering');
+const communityPosts = posts.filter(post => post.data.track === 'community');
 ---
 
 <!doctype html>
@@ -125,6 +126,25 @@ const engineeringPosts = posts.filter(post => post.data.track === 'engineering')
 				<ul>
 					{
 						engineeringPosts.map((post) => (
+							<li>
+								<a href={post.id}>
+									<img width={720} height={360} src={post.data.heroImage} alt="" />
+									<h4 class="title">{post.data.title}</h4>
+									<p class="date">
+										<FormattedDate date={post.data.pubDate} />
+									</p>
+								</a>
+							</li>
+						))
+					}
+				</ul>
+			</section>
+			
+			<section class="track-section">
+				<h2 class="track-title">Community</h2>
+				<ul>
+					{
+						communityPosts.map((post) => (
 							<li>
 								<a href={post.id}>
 									<img width={720} height={360} src={post.data.heroImage} alt="" />

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -9,17 +9,6 @@ import FormattedDate from '../components/FormattedDate.astro';
 const posts = (await getCollection('blog'))
 	.filter(post => post.data.track === 'community')
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-
-// Helper function to fix hero image URLs
-const getImageUrl = (heroImage) => {
-	if (!heroImage) return '';
-	return heroImage.startsWith('/') ? `https://blog.trustyai.org${heroImage}` : heroImage;
-};
-
-// Helper function to get the correct post URL for community posts
-const getPostUrl = (post) => {
-	return `https://blog.trustyai.org/community/${post.id.replace('community/', '')}`;
-};
 ---
 
 <!doctype html>
@@ -124,8 +113,8 @@ const getPostUrl = (post) => {
 					{
 						posts.map((post) => (
 							<li>
-								<a href={getPostUrl(post)}>
-									<img width={720} height={360} src={getImageUrl(post.data.heroImage)} alt="" />
+								<a href={post.id}>
+									<img width={720} height={360} src={post.data.heroImage} alt="" />
 									<h4 class="title">{post.data.title}</h4>
 									<p class="date">
 										<FormattedDate date={post.data.pubDate} />

--- a/src/pages/engineering.astro
+++ b/src/pages/engineering.astro
@@ -9,17 +9,6 @@ import FormattedDate from '../components/FormattedDate.astro';
 const posts = (await getCollection('blog'))
 	.filter(post => post.data.track === 'engineering')
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-
-// Helper function to fix hero image URLs
-const getImageUrl = (heroImage) => {
-	if (!heroImage) return '';
-	return heroImage.startsWith('/') ? `https://blog.trustyai.org${heroImage}` : heroImage;
-};
-
-// Helper function to get the correct post URL for engineering posts
-const getPostUrl = (post) => {
-	return `https://blog.trustyai.org/engineering/${post.id.replace('engineering/', '')}`;
-};
 ---
 
 <!doctype html>
@@ -124,8 +113,8 @@ const getPostUrl = (post) => {
 					{
 						posts.map((post) => (
 							<li>
-								<a href={getPostUrl(post)}>
-									<img width={720} height={360} src={getImageUrl(post.data.heroImage)} alt="" />
+								<a href={post.id}>
+									<img width={720} height={360} src={post.data.heroImage} alt="" />
 									<h4 class="title">{post.data.title}</h4>
 									<p class="date">
 										<FormattedDate date={post.data.pubDate} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,25 +11,6 @@ import { getBaseUrl } from '../utils/urls';
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
-
-// Helper function to fix hero image URLs
-const getImageUrl = (heroImage) => {
-	if (!heroImage) return '';
-	return heroImage.startsWith('/') ? `${import.meta.env.BASE_URL}/${heroImage.slice(1)}` : heroImage;
-};
-
-// Helper function to get the correct post URL
-const getPostUrl = (post) => {
-	const baseUrl = getBaseUrl();
-	if (post.data.track === 'research') {
-		return `${baseUrl}/research/${post.id.replace('research/', '')}`;
-	} else if (post.data.track === 'engineering') {
-		return `${baseUrl}/engineering/${post.id.replace('engineering/', '')}`;
-	} else {
-		// For posts not in subdirectories
-		return `${baseUrl}/blog/${post.id}`;
-	}
-};
 ---
 
 <!doctype html>
@@ -153,33 +134,21 @@ const getPostUrl = (post) => {
 			<section class="posts-section">
 				<ul>
 					{
-						posts.map((post) => {
-							let postUrl = '';
-							if (post.data.track === 'research') {
-								postUrl = `${baseUrl}/research/${post.id.replace('research/', '')}`;
-							} else if (post.data.track === 'engineering') {
-								postUrl = `${baseUrl}/engineering/${post.id.replace('engineering/', '')}`;
-							} else if (post.data.track === 'community') {
-								postUrl = `${baseUrl}/community/${post.id.replace('community/', '')}`;
-							} else {
-								postUrl = `${baseUrl}/blog/${post.id}`;
-							}
-							return (
-								<li>
-									<span class={`track-badge ${post.data.track}`}>
-										{post.data.track}
-									</span>
-									<a href={postUrl}>
-										<img width={720} height={360} src={getImageUrl(post.data.heroImage)} alt="" />
-										<h4 class="title">{post.data.title}</h4>
-										<p class="date">
-											<span class="track-text">{post.data.track}</span>
-											<FormattedDate date={post.data.pubDate} />
-										</p>
-									</a>
-								</li>
-							);
-						})
+						posts.map((post) => (
+							<li>
+								<span class={`track-badge ${post.data.track}`}>
+									{post.data.track}
+								</span>
+								<a href={post.id}>
+									<img width={720} height={360} src={post.data.heroImage} alt="" />
+									<h4 class="title">{post.data.title}</h4>
+									<p class="date">
+										<span class="track-text">{post.data.track}</span>
+										<FormattedDate date={post.data.pubDate} />
+									</p>
+								</a>
+							</li>
+						))
 					}
 				</ul>
 			</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,11 +5,31 @@ import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 import { getCollection } from 'astro:content';
 import FormattedDate from '../components/FormattedDate.astro';
-import { getImageUrl, getPostUrl } from '../utils/urls';
+import { getBaseUrl } from '../utils/urls';
+
 
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
+
+// Helper function to fix hero image URLs
+const getImageUrl = (heroImage) => {
+	if (!heroImage) return '';
+	return heroImage.startsWith('/') ? `${import.meta.env.BASE_URL}/${heroImage.slice(1)}` : heroImage;
+};
+
+// Helper function to get the correct post URL
+const getPostUrl = (post) => {
+	const baseUrl = getBaseUrl();
+	if (post.data.track === 'research') {
+		return `${baseUrl}/research/${post.id.replace('research/', '')}`;
+	} else if (post.data.track === 'engineering') {
+		return `${baseUrl}/engineering/${post.id.replace('engineering/', '')}`;
+	} else {
+		// For posts not in subdirectories
+		return `${baseUrl}/blog/${post.id}`;
+	}
+};
 ---
 
 <!doctype html>
@@ -133,21 +153,33 @@ const posts = (await getCollection('blog')).sort(
 			<section class="posts-section">
 				<ul>
 					{
-						posts.map((post) => (
-							<li>
-								<span class={`track-badge ${post.data.track}`}>
-									{post.data.track}
-								</span>
-								<a href={getPostUrl(post)}>
-									<img width={720} height={360} src={getImageUrl(post.data.heroImage)} alt="" />
-									<h4 class="title">{post.data.title}</h4>
-									<p class="date">
-										<span class="track-text">{post.data.track}</span>
-										<FormattedDate date={post.data.pubDate} />
-									</p>
-								</a>
-							</li>
-						))
+						posts.map((post) => {
+							let postUrl = '';
+							if (post.data.track === 'research') {
+								postUrl = `${baseUrl}/research/${post.id.replace('research/', '')}`;
+							} else if (post.data.track === 'engineering') {
+								postUrl = `${baseUrl}/engineering/${post.id.replace('engineering/', '')}`;
+							} else if (post.data.track === 'community') {
+								postUrl = `${baseUrl}/community/${post.id.replace('community/', '')}`;
+							} else {
+								postUrl = `${baseUrl}/blog/${post.id}`;
+							}
+							return (
+								<li>
+									<span class={`track-badge ${post.data.track}`}>
+										{post.data.track}
+									</span>
+									<a href={postUrl}>
+										<img width={720} height={360} src={getImageUrl(post.data.heroImage)} alt="" />
+										<h4 class="title">{post.data.title}</h4>
+										<p class="date">
+											<span class="track-text">{post.data.track}</span>
+											<FormattedDate date={post.data.pubDate} />
+										</p>
+									</a>
+								</li>
+							);
+						})
 					}
 				</ul>
 			</section>

--- a/src/pages/research.astro
+++ b/src/pages/research.astro
@@ -9,17 +9,6 @@ import FormattedDate from '../components/FormattedDate.astro';
 const posts = (await getCollection('blog'))
 	.filter(post => post.data.track === 'research')
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-
-// Helper function to fix hero image URLs
-const getImageUrl = (heroImage) => {
-	if (!heroImage) return '';
-	return heroImage.startsWith('/') ? `https://blog.trustyai.org${heroImage}` : heroImage;
-};
-
-// Helper function to get the correct post URL for research posts
-const getPostUrl = (post) => {
-	return `https://blog.trustyai.org/research/${post.id.replace('research/', '')}`;
-};
 ---
 
 <!doctype html>
@@ -124,8 +113,8 @@ const getPostUrl = (post) => {
 					{
 						posts.map((post) => (
 							<li>
-								<a href={getPostUrl(post)}>
-									<img width={720} height={360} src={getImageUrl(post.data.heroImage)} alt="" />
+								<a href={post.id}>
+									<img width={720} height={360} src={post.data.heroImage} alt="" />
 									<h4 class="title">{post.data.title}</h4>
 									<p class="date">
 										<FormattedDate date={post.data.pubDate} />

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -31,5 +31,8 @@ export function getBlogPostUrl(postId: string): string {
 
 // when using a relative base, import.meta.env.BASE_URL will be '/./'
 export const getBaseUrl = () => {
-	return import.meta.env.BASE_URL === '/./' ? '' : import.meta.env.BASE_URL;
+	if (import.meta.env.BASE_URL === '/./' || import.meta.env.BASE_URL === '/') {
+		return '';
+	}
+	return import.meta.env.BASE_URL;
 }; 

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,33 +1,4 @@
-// Utility functions for URL generation - always use blog.trustyai.org
-const SITE_URL = 'https://blog.trustyai.org';
-
-export function getImageUrl(heroImage: string): string {
-	if (!heroImage) return '';
-	return heroImage.startsWith('/') ? `${SITE_URL}${heroImage}` : heroImage;
-}
-
-export function getPostUrl(post: any): string {
-	if (post.data.track === 'research') {
-		return `${SITE_URL}/research/${post.id.replace('research/', '')}`;
-	} else if (post.data.track === 'engineering') {
-		return `${SITE_URL}/engineering/${post.id.replace('engineering/', '')}`;
-	} else {
-		// For posts not in subdirectories
-		return `${SITE_URL}/blog/${post.id}`;
-	}
-}
-
-export function getAuthorUrl(authorId: string): string {
-	return `${SITE_URL}/authors/${authorId}/`;
-}
-
-export function getAssetUrl(path: string): string {
-	return `${SITE_URL}${path}`;
-}
-
-export function getBlogPostUrl(postId: string): string {
-	return `${SITE_URL}/blog/${postId}/`;
-} 
+// Utility functions for URL generation
 
 // when using a relative base, import.meta.env.BASE_URL will be '/./'
 export const getBaseUrl = () => {

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -28,3 +28,8 @@ export function getAssetUrl(path: string): string {
 export function getBlogPostUrl(postId: string): string {
 	return `${SITE_URL}/blog/${postId}/`;
 } 
+
+// when using a relative base, import.meta.env.BASE_URL will be '/./'
+export const getBaseUrl = () => {
+	return import.meta.env.BASE_URL === '/./' ? '' : import.meta.env.BASE_URL;
+}; 


### PR DESCRIPTION
Using relative paths like this works in local dev w/ all the images, and you don't need to do any of the helper functions to manipulate the paths. Now all urls work, except for misplaced .md's (eg., track is research but not in the research folder) which i think is what we want.