### PR TITLE
Show full author name for Diego

### DIFF
--- a/src/content/authors/diego.md
+++ b/src/content/authors/diego.md
@@ -1,5 +1,5 @@
 ---
-name: 'Diego'
+name: 'Diego Maniloff'
 bio: 'Principal Machine Learning Engineer at Red Hat'
 avatar: '/authors/diego.jpg'
 linkedin: 'diegomaniloff'


### PR DESCRIPTION
## What

Updates the author name from `Diego` to `Diego Maniloff` in `src/content/authors/diego.md`.

## Why

Only the first name was showing on blog posts and the author page. This displays the full name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)