### PR TITLE
Fix date of MiDojo intro post

### DIFF
--- a/src/content/blog/community/midojo-intro.mdx
+++ b/src/content/blog/community/midojo-intro.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'MiDojo: Red-Team Any Agent in Any Environment'
 description: "An introduction to MiDojo, a framework that red-teams AI agents where they actually run. We walk through the man-in-the-middle design and a hello-world weather suite end to end — authoring fake tools, planting a prompt injection, and grading utility and security."
-pubDate: 'Jun 23 2026'
+pubDate: 'Jun 4 2026'
 heroImage: '/blog-placeholder-3.jpg'
 track: 'community'
 authors: ['diego']


### PR DESCRIPTION
## What

Fix `pubDate` of the MiDojo intro post from `Jun 23 2026` to `Jun 4 2026`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)