### PR TITLE
Fix broken post links on author pages

### DIFF
--- a/src/pages/authors/[...slug].astro
+++ b/src/pages/authors/[...slug].astro
@@ -62,7 +62,7 @@ const authorPosts = allPosts.filter(post =>
 						<ul class="post-list">
 							{authorPosts.map((post) => (
 								<li>
-									<a href={`${baseUrl}/${post.id}`}>
+									<a href={`${baseUrl}/blog/${post.id}`}>
 										<div class="post-info">
 											<h3>{post.data.title}</h3>
 											<p>{post.data.description}</p>


### PR DESCRIPTION
## What

Adds the missing `/blog` prefix to the post links in the "Blog Posts by &lt;author&gt;" list on author pages.

## Why

The links pointed to `/<post.id>` (e.g. `/community/midojo-intro`), but posts are served at `/blog/<post.id>` (e.g. `/blog/community/midojo-intro`) — so the links 404'd. Now matches the convention used on the homepage.

## Notes

Verified with `npm run build` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)