### PR TITLE
Reduce type scale and code block sizing site-wide

### DIFF
--- a/src/content/blog/midojo-intro.mdx
+++ b/src/content/blog/midojo-intro.mdx
@@ -8,9 +8,8 @@ authors: ['diego']
 tags: ['security', 'agents', 'red-teaming', 'prompt-injection', 'agentic-ai']
 ---
 
-{/* Slightly smaller code blocks, to roughly match the rendered run-output SVG. Scoped to this post. */}
+{/* Figure/caption styling scoped to this post. */}
 <style>{`
-  .prose pre { font-size: 0.8em; }
   .prose figure { margin: 1.5em 0; text-align: center; }
   .prose figure img { max-width: 100%; height: auto; }
   .prose figcaption { margin-top: 0.5em; font-size: 0.85em; color: rgb(var(--gray)); font-style: italic; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,19 +46,19 @@ h6 {
 	line-height: 1.2;
 }
 h1 {
-	font-size: 3.052em;
+	font-size: 2.488em;
 }
 h2 {
-	font-size: 2.441em;
+	font-size: 2.074em;
 }
 h3 {
-	font-size: 1.953em;
+	font-size: 1.728em;
 }
 h4 {
-	font-size: 1.563em;
+	font-size: 1.44em;
 }
 h5 {
-	font-size: 1.25em;
+	font-size: 1.2em;
 }
 strong,
 b {
@@ -96,10 +96,12 @@ code {
 	background-color: rgb(var(--gray-light));
 	border-radius: 2px;
 	font-family: 'Fira Code', monospace;
+	font-size: 0.8em;
 }
 pre {
 	padding: 1.5em;
 	border-radius: 8px;
+	font-size: 0.72em;
 }
 pre > code {
 	all: unset;
@@ -121,6 +123,18 @@ hr {
 	}
 	main {
 		padding: 1em;
+	}
+	h1 {
+		font-size: 1.9em;
+	}
+	h2 {
+		font-size: 1.6em;
+	}
+	h3 {
+		font-size: 1.4em;
+	}
+	h4 {
+		font-size: 1.25em;
 	}
 }
 


### PR DESCRIPTION
## What

Site-wide typography tuning — headings and code felt oversized, especially on mobile.

- **Headings:** softened the scale from 1.25 (major third) to **1.2** (minor third). Post `h1` ~61px → ~50px, `h2` ~49px → ~41px, `h3` ~39px → ~35px. Body stays 20px.
- **Mobile:** added heading sizes under `@media (max-width: 720px)` so titles no longer wrap to 4 lines on phones (`h1` ~34px, etc.).
- **Code:** code blocks (`pre`) → **0.72em** and inline `code` → **0.8em**, globally.
- Removed the now-redundant per-post `.prose pre` override from the MiDojo post (its figure/caption styles are unchanged).

## Notes

All changes live in `src/styles/global.css` (plus the one-line cleanup in the MiDojo post). Verified with `npm run build` (clean) and locally on desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)