### PR TITLE
:bug: fix tags

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -138,7 +138,7 @@ const posts = (await getCollection('blog'))
 					{
 						posts.map((post) => (
 							<li>
-								<a href={`${baseUrl}/${post.id}`}>
+								<a href={`${baseUrl}/blog/${post.id}`}>
 									<img width={720} height={360} src={post.data.heroImage} alt="" />
 									<h4 class="title">{post.data.title}</h4>
 									<p class="date">


### PR DESCRIPTION
Changed the href to ${baseUrl}/blog/${post.id} so links resolve to /blog/midojo-intro, /blog/engineering/automated-red-teaming, etc.